### PR TITLE
Update service name for SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Deploy on Toolforge
 Your tool will need a service account with rights to query across namespaces.
 
 ```
-$ ssh dev.tools.wmflabs.org
+$ ssh dev.toolforge.org
 $ become $TOOL_NAME
 $ mkdir -p $HOME/www/python
 $ git clone https://phabricator.wikimedia.org/source/tool-k8s-status.git \


### PR DESCRIPTION
See https://wikitech.wikimedia.org/wiki/News/Toolforge.org#New_service_names_for_accessing_Toolforge_SSH_bastions for more information